### PR TITLE
Make compatible with Django 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='django-tastypie',
-    version='0.11.9-dev',
+    version='0.12.0',
     description='A flexible & capable API layer for Django.',
     author='Daniel Lindsley',
     author_email='daniel@toastdriven.com',

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,12 +1,15 @@
 from __future__ import unicode_literals
 import warnings
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from tastypie.exceptions import NotRegistered, BadRequest
 from tastypie.serializers import Serializer
-from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value
+from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value, \
+    IS_DJANGO_1_4
+if IS_DJANGO_1_4:
+    from django.conf.urls import patterns
 from tastypie.utils.mime import determine_format, build_content_type
 
 
@@ -113,9 +116,10 @@ class Api(object):
             warnings.warn("'override_urls' is a deprecated method & will be removed by v1.0.0. Please rename your method to ``prepend_urls``.")
             urlpatterns += overridden_urls
 
-        urlpatterns += patterns('',
-            *pattern_list
-        )
+        if IS_DJANGO_1_4:
+            urlpatterns += patterns('', *pattern_list)
+        else:
+            urlpatterns = pattern_list
         return urlpatterns
 
     def top_level(self, request, api_name=None):

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import _sanitize_token, constant_time_compare
-from django.utils.http import same_origin
+from tastypie.utils.http import same_origin
 from django.utils.translation import ugettext as _
 from tastypie.http import HttpUnauthorized
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -11,7 +11,6 @@ from django.middleware.csrf import _sanitize_token, constant_time_compare
 from django.utils.http import same_origin
 from django.utils.translation import ugettext as _
 from tastypie.http import HttpUnauthorized
-from tastypie.compat import User, username_field
 
 try:
     from hashlib import sha1
@@ -180,7 +179,9 @@ class ApiKeyAuthentication(Authentication):
         Should return either ``True`` if allowed, ``False`` if not or an
         ``HttpResponse`` if you need something custom.
         """
-        from tastypie.compat import User
+        from tastypie.compat import get_user_model, get_username_field
+        User = get_user_model()
+        username_field = get_username_field()
 
         try:
             username, api_key = self.extract_credentials(request)
@@ -280,6 +281,8 @@ class SessionAuthentication(Authentication):
 
         This implementation returns the user's username.
         """
+        from tastypie.compat import get_username_field
+        username_field = get_username_field()
         return getattr(request.user, username_field)
 
 
@@ -366,6 +369,9 @@ class DigestAuthentication(Authentication):
         return True
 
     def get_user(self, username):
+        from tastypie.compat import get_user_model, get_username_field
+        User = get_user_model()
+        username_field = get_username_field()
         try:
             lookup_kwargs = {username_field: username}
             user = User.objects.get(**lookup_kwargs)

--- a/tastypie/bundle_pre_processor.py
+++ b/tastypie/bundle_pre_processor.py
@@ -1,5 +1,5 @@
 from tastypie.exceptions import TastypieError, Unauthorized
-from django.utils import importlib
+import importlib
 
 
 class BundlePreProcessor(object):

--- a/tastypie/cache.py
+++ b/tastypie/cache.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.core.cache import get_cache
+from django.core.cache import caches
 
 
 class NoCache(object):
@@ -59,7 +59,7 @@ class SimpleCache(NoCache):
         Defaults to ``60`` seconds.
         """
         super(SimpleCache, self).__init__(*args, **kwargs)
-        self.cache = get_cache(cache_name)
+        self.cache = caches[cache_name]
         self.timeout = timeout or self.cache.default_timeout
         self.public = public
         self.private = private

--- a/tastypie/cache.py
+++ b/tastypie/cache.py
@@ -1,5 +1,11 @@
 from __future__ import unicode_literals
-from django.core.cache import caches
+
+from tastypie.utils import IS_DJANGO_1_4
+
+if IS_DJANGO_1_4:
+    from django.core.cache import get_cache
+else:
+    from django.core.cache import caches
 
 
 class NoCache(object):
@@ -59,7 +65,10 @@ class SimpleCache(NoCache):
         Defaults to ``60`` seconds.
         """
         super(SimpleCache, self).__init__(*args, **kwargs)
-        self.cache = caches[cache_name]
+        if IS_DJANGO_1_4:
+            self.cache = get_cache(cache_name)
+        else:
+            self.cache = caches[cache_name]
         self.timeout = timeout or self.cache.default_timeout
         self.public = public
         self.private = private

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -3,22 +3,38 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 import django
 
-__all__ = ['User', 'AUTH_USER_MODEL']
+__all__ = ['AUTH_USER_MODEL', 'get_username_field', 'get_user_model']
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
-# Django 1.5+ compatibility
-if django.VERSION >= (1, 5):
-    try:
-        from django.contrib.auth import get_user_model
-        User = get_user_model()
-        username_field = User.USERNAME_FIELD
-    except ImproperlyConfigured:
-        # The the users model might not be read yet.
-        # This can happen is when setting up the create_api_key signal, in your
-        # custom user module.
-        User = None
-        username_field = None
-else:
-    from django.contrib.auth.models import User
-    username_field = 'username'
+
+def get_username_field():
+    # Django 1.5+ compatibility
+    if django.VERSION >= (1, 5):
+        try:
+            from django.contrib.auth import get_user_model as get_user
+            User = get_user()
+            return User.USERNAME_FIELD
+        except ImproperlyConfigured:
+            # The the users model might not be read yet.
+            # This can happen is when setting up the create_api_key signal, in your
+            # custom user module.
+            return None
+    else:
+        return 'username'
+
+
+def get_user_model():
+    if django.VERSION >= (1, 5):
+        try:
+            from django.contrib.auth import get_user_model as get_user
+            User = get_user()
+            return User
+        except ImproperlyConfigured:
+            # The the users model might not be read yet.
+            # This can happen is when setting up the create_api_key signal, in your
+            # custom user module.
+            return None
+    else:
+        from django.contrib.auth.models import User
+        return User

--- a/tastypie/event_handler.py
+++ b/tastypie/event_handler.py
@@ -1,5 +1,5 @@
 from tastypie.exceptions import TastypieError, Unauthorized
-from django.utils import importlib
+import importlib
 
 
 class EventHandler(object):

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -4,15 +4,15 @@ from dateutil.parser import parse
 from decimal import Decimal
 import re
 from django import forms
-from django.utils.functional import memoize
 
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django import forms as djangoform
-from django.utils import datetime_safe, importlib
+from django.utils import datetime_safe
+from importlib import import_module
 from django.utils import six
 from tastypie.bundle import Bundle
-from tastypie.exceptions import ApiFieldError, NotFound, HydrationError
-from tastypie.utils import dict_strip_unicode_keys, make_aware, LimitedSizeDict
+from tastypie.exceptions import ApiFieldError, NotFound
+from tastypie.utils import dict_strip_unicode_keys, make_aware
 
 
 class NOT_PROVIDED:
@@ -634,7 +634,7 @@ class RelatedField(ApiField):
             # Try to import.
             module_bits = self.to.split('.')
             module_path, class_name = '.'.join(module_bits[:-1]), module_bits[-1]
-            module = importlib.import_module(module_path)
+            module = import_module(module_path)
         else:
             # We've got a bare class name here, which won't work (No AppCache
             # to rely on). Try to throw a useful error.

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -6,7 +6,13 @@ import logging
 import warnings
 
 from django.conf import settings
-from django.conf.urls import url, include
+
+from tastypie.utils import IS_DJANGO_1_4
+if IS_DJANGO_1_4:
+    from django.conf.urls import url, patterns, include
+else:
+    from django.conf.urls import url, include
+
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError, ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix, reverse_lazy
 from django.core.signals import got_request_exception
@@ -70,7 +76,10 @@ class NOT_AVAILABLE:
 class CustomRegexURLResolver(RegexURLResolver):
     @property
     def url_patterns(self):
-        url_patterns = patterns("", *self.urlconf_name)
+        if IS_DJANGO_1_4:
+            url_patterns = patterns("", *self.urlconf_name)
+        else:
+            url_patterns = self.urlconf_name
         try:
             iter(url_patterns)
         except TypeError:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError, ImproperlyConfigured
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix, reverse_lazy
 from django.core.signals import got_request_exception
@@ -480,10 +480,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         urls += self.base_urls()
         urls += self.sub_resource_urls()
-        urlpatterns = patterns('',
-            *urls
-        )
-        return urlpatterns
+        return urls
 
     def determine_format(self, request):
         """

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -55,6 +55,12 @@ from bson import ObjectId
 from pymongo import MongoClient
 from tastypie.bundle import Bundle
 
+
+try:
+    commit_on_success = transaction.atomic
+except AttributeError:
+    commit_on_success = transaction.commit_on_success
+
 try:
     set
 except NameError:
@@ -2593,7 +2599,7 @@ class BaseModelResource(Resource):
         bundle.obj.delete()
         self.fire_event('detail_deleted', args=(self.get_object_list(bundle.request), bundle))
 
-    @transaction.commit_on_success()
+    @commit_on_success()
     def patch_list(self, request, **kwargs):
         """
         An ORM-specific implementation of ``patch_list``.

--- a/tastypie/utils/__init__.py
+++ b/tastypie/utils/__init__.py
@@ -5,6 +5,11 @@ from tastypie.utils.validate_jsonp import is_valid_jsonp_callback_value
 from tastypie.utils.timezone import now, make_aware, make_naive, aware_date, aware_datetime
 import inspect
 
+import django
+
+IS_DJANGO_1_4 = django.get_version().startswith('1.4')
+
+
 def get_current_func_name():
     """for python version greater than equal to 2.7"""
     return inspect.stack()[1][3]

--- a/tastypie/utils/http.py
+++ b/tastypie/utils/http.py
@@ -1,0 +1,19 @@
+from django.utils.six.moves.urllib.parse import urlparse
+
+
+PROTOCOL_TO_PORT = {
+    'http': 80,
+    'https': 443,
+}
+
+def same_origin(url1, url2):
+    """
+    Checks if two URLs are 'same-origin'
+    """
+    p1, p2 = urlparse(url1), urlparse(url2)
+    try:
+        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
+        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
+        return o1 == o2
+    except (ValueError, KeyError):
+        return False

--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ModelForm
 from django.forms.models import model_to_dict
-from django.utils import importlib
+import importlib
 
 
 class Validation(object):


### PR DESCRIPTION
These changes are a step towards making this library compatible with Django 1.10.
This library was written for Django 1.4 which is not supported anymore, these changes are backwards compatible.

For deprecated APIs check:
https://docs.djangoproject.com/en/dev/internals/deprecation/