### PR TITLE
futurize to py2/3 compatibility

### DIFF
--- a/tastypie/__init__.py
+++ b/tastypie/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 
 __author__ = 'Daniel Lindsley & the Tastypie core team'
 __version__ = (0, 11, 9, 'dev')
 
 from django.core.handlers.wsgi import WSGIRequest
-from response_dispatcher import HttpResponseDispatcher
-from response_router import ResponseRouter
+from .response_dispatcher import HttpResponseDispatcher
+from .response_router import ResponseRouter
 response_router_obj = ResponseRouter()
 response_router_obj[WSGIRequest] = HttpResponseDispatcher()
 

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 import warnings
 from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 import base64
 import hmac
 import time

--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 from tastypie.exceptions import TastypieError, Unauthorized
 
 

--- a/tastypie/bundle.py
+++ b/tastypie/bundle.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 from django.http import HttpRequest
 
 

--- a/tastypie/bundle_pre_processor.py
+++ b/tastypie/bundle_pre_processor.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 from tastypie.exceptions import TastypieError, Unauthorized
 import importlib
 

--- a/tastypie/cache.py
+++ b/tastypie/cache.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from builtins import object
 from tastypie.utils import IS_DJANGO_1_4
 
 if IS_DJANGO_1_4:

--- a/tastypie/contrib/contenttypes/fields.py
+++ b/tastypie/contrib/contenttypes/fields.py
@@ -21,7 +21,7 @@ class GenericForeignKeyField(fields.ToOneField):
         if len(to) <= 0:
             raise ValueError('to field must have some values')
 
-        for k, v in to.items():
+        for k, v in list(to.items()):
             if not issubclass(k, models.Model) or not issubclass(v, Resource):
                 raise ValueError('to field must map django models to tastypie resources')
 
@@ -64,7 +64,7 @@ class GenericForeignKeyField(fields.ToOneField):
             #this case should never happen. self._to_class should always be none
             return self._to_class
 
-        return partial(GenericResource, resources=self.to.values())
+        return partial(GenericResource, resources=list(self.to.values()))
 
     def resource_from_uri(self, fk_resource, uri, request=None, related_obj=None, related_name=None):
         try:

--- a/tastypie/contrib/gis/resources.py
+++ b/tastypie/contrib/gis/resources.py
@@ -1,7 +1,9 @@
 # See COPYING file in this directory.
 # Some code originally from django-boundaryservice
 from __future__ import unicode_literals
-from urllib import unquote
+from future import standard_library
+standard_library.install_aliases()
+from urllib.parse import unquote
 
 from django.contrib.gis.db.models import GeometryField
 from django.contrib.gis.geos import GEOSGeometry

--- a/tastypie/event_handler.py
+++ b/tastypie/event_handler.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 from tastypie.exceptions import TastypieError, Unauthorized
 import importlib
 

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 import datetime
 from dateutil.parser import parse
 from decimal import Decimal
@@ -15,7 +18,7 @@ from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys, make_aware
 
 
-class NOT_PROVIDED:
+class NOT_PROVIDED(object):
     def __str__(self):
         return 'No default provided.'
 
@@ -584,7 +587,7 @@ class RelatedField(ApiField):
             data['fields'][field_name]['schema'] ="%s%s/schema/"%(self.get_resource_uri(),field_name)
         else:
             related_resource = field_object.get_related_resource()
-            data['fields'][field_name]['schema'] = unicode(related_resource.get_resource_uri())+ "schema/"  #unicode(.get_resource_uri()) + "schema/"
+            data['fields'][field_name]['schema'] = str(related_resource.get_resource_uri())+ "schema/"  #unicode(.get_resource_uri()) + "schema/"
 
             if related_resource._meta.include_resource_uri==False or not field_object.to_class().get_resource_uri():
                 data['fields'][field_name]['schema'] = field_object.to_class().build_schema()
@@ -723,14 +726,14 @@ class RelatedField(ApiField):
             fk_bundle.related_obj = related_obj
             fk_bundle.related_name = related_name
 
-        unique_keys = dict((k, v) for k, v in data.items() if k == 'pk' or (hasattr(fk_resource, k) and getattr(fk_resource, k).unique))
+        unique_keys = dict((k, v) for k, v in list(data.items()) if k == 'pk' or (hasattr(fk_resource, k) and getattr(fk_resource, k).unique))
 
         try:
             fk_bundle.obj =  self.get_obj_from_data(fk_resource, fk_bundle, **data)
         except (NotFound, TypeError):
             try:
                 # Attempt lookup by primary key
-                lookup_kwargs = dict((k, v) for k, v in data.iteritems()
+                lookup_kwargs = dict((k, v) for k, v in data.items()
                                      if (hasattr(fk_resource, k) and
                                          getattr(fk_resource, k).unique))
                 if not lookup_kwargs:

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 import hmac
 import time
 from django.conf import settings
@@ -50,7 +51,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
             # Hmac that beast.
             return hmac.new(new_uuid.bytes, digestmod=sha1).hexdigest()
 
-        class Meta:
+        class Meta(object):
             abstract = getattr(settings, 'TASTYPIE_ABSTRACT_APIKEY', False)
 
 

--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 from django.conf import settings
 from django.utils import six
 
@@ -8,7 +11,7 @@ from tastypie.exceptions import BadRequest
 try:
     from urllib.parse import urlencode
 except ImportError:
-    from urllib import urlencode
+    from urllib.parse import urlencode
 
 
 class Paginator(object):
@@ -164,7 +167,7 @@ class Paginator(object):
         except AttributeError:
             request_params = {}
 
-            for k, v in self.request_data.items():
+            for k, v in list(self.request_data.items()):
                 if isinstance(v, six.text_type):
                     request_params[k] = v.encode('utf-8')
                 else:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -292,10 +292,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             except (BadRequest, fields.ApiFieldError) as e:
                 data = {"error": e.args[0] if getattr(e, 'args') else ''}
                 return self.error_response(request, data, response_class=self._meta.response_router_obj[request].get_bad_request_response_class())
-            except ValidationError, e:
+            except ValidationError as e:
                 data = {"error": e.messages}
                 return self.error_response(request, data, response_class=self._meta.response_router_obj[request].get_bad_request_response_class())
-            except Exception, e:
+            except Exception as e:
                 return self._handle_500(request, e)
 
         return wrapper
@@ -537,10 +537,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         """
         try:
             deserialized = self._meta.serializer.deserialize(data, format=request.META.get('CONTENT_TYPE', 'application/json'))
-        except UnsupportedFormat, e:
+        except UnsupportedFormat as e:
             errors = {"errors": e.message}
             raise ImmediateResponse(response=self.error_response(request, errors))
-        except ValueError, e:
+        except ValueError as e:
             errors = {"errors": "Please provide a proper JSON string!"}
             raise ImmediateResponse(response=self.error_response(request, errors))
         return deserialized
@@ -759,13 +759,13 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
     def is_authorized(self, action,object_list, bundle ):
         try:
             auth_result = getattr(self._meta.authorization, action)(object_list, bundle)
-        except Unauthorized, exception:
+        except Unauthorized as exception:
             response = self._meta.response_router_obj[bundle.request].get_unauthorized_request_response()
             response.content = exception.message
             raise ImmediateResponse(response=response)
 
             #self.unauthorized_result(bundle.request, e)
-        except Forbidden, exception:
+        except Forbidden as exception:
 
             response_class = self._meta.response_router_obj[bundle.request].get_forbidden_response_class()
             errors = {"error_type":exception.error_type,
@@ -1472,7 +1472,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             if not field_object.attribute:
                 continue
 
-            if field_object.blank and (not bundle.data.has_key(field_name) or bundle.data.get(field_name) is None):
+            if field_object.blank and (field_name not in bundle.data or bundle.data.get(field_name) is None):
                 continue
 
 
@@ -2219,7 +2219,7 @@ class BaseModelResource(Resource):
                 else:
                     value = value.split(',')
             return value
-        except Exception, e:
+        except Exception as e:
             try:
                 logger = logging.getLogger("tastypie.resources.filter_value_to_python")
                 logger.error("filter_value_to_python - value-%s  filters-%s filter_expr-%s"%(value, filters, filter_expr))
@@ -2700,7 +2700,7 @@ class BaseModelResource(Resource):
 
             if field_object.readonly:
                 continue
-            if field_object.blank and not bundle.data.has_key(field_name):
+            if field_object.blank and field_name not in bundle.data:
                 continue
 
             field_object.save(bundle)

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import with_statement
+from past.builtins import basestring
+from builtins import object
 import simplejson
 from copy import deepcopy
 import logging
@@ -75,7 +77,7 @@ except ImportError:
 
 
 
-class NOT_AVAILABLE:
+class NOT_AVAILABLE(object):
     def __str__(self):
         return 'No such data is available.'
 
@@ -175,12 +177,12 @@ class DeclarativeMetaclass(type):
             for p in parents:
                 parent_fields = getattr(p, 'base_fields', {})
 
-                for field_name, field_object in parent_fields.items():
+                for field_name, field_object in list(parent_fields.items()):
                     attrs['base_fields'][field_name] = deepcopy(field_object)
         except NameError:
             pass
 
-        for field_name, obj in attrs.copy().items():
+        for field_name, obj in list(attrs.copy().items()):
             # Look for ``dehydrated_type`` instead of doing ``isinstance``,
             # which can break down if Tastypie is re-namespaced as something
             # else.
@@ -207,7 +209,7 @@ class DeclarativeMetaclass(type):
         elif 'resource_uri' in new_class.base_fields and not 'resource_uri' in attrs:
             del(new_class.base_fields['resource_uri'])
 
-        for field_name, field_object in new_class.base_fields.items():
+        for field_name, field_object in list(new_class.base_fields.items()):
             if hasattr(field_object, 'contribute_to_class'):
                 field_object.contribute_to_class(new_class, field_name)
 
@@ -226,7 +228,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
     data sources, such as search results, files, other data, etc.
     """
     def __init__(self, api_name=None, parent_resource=None, parent_pk=None, parent_obj=None, parent_field=None):
-        self.fields = {k: copy(v) for k, v in self.base_fields.iteritems()}
+        self.fields = {k: copy(v) for k, v in self.base_fields.items()}
         self.parent_resource=parent_resource
         self.parent_pk = parent_pk
         self.parent_obj = parent_obj
@@ -444,7 +446,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         sub_resource_field_list = []
         url_list=[]
 
-        for name, field in self.fields.items():
+        for name, field in list(self.fields.items()):
             if isinstance(field, fields.BaseSubResourceField):
                 url_list += [url(r"^(?P<resource_name>%s)/(?P<sub_resource_name>.+)/schema/"%(self._meta.resource_name,), self.wrap_view('build_sub_resource_schema'), name="%s_%s_schema"%(self._meta.resource_name,field.get_related_resource()._meta.resource_name) )]
                 sub_resource_field_list.append(field)
@@ -456,7 +458,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                     self.wrap_view('view_to_handle_subresource'), {'%s_sub_resource_field_list'%(self._meta.resource_name): sub_resource_field_list}),
             ]
 
-        for name, field in self.fields.items():
+        for name, field in list(self.fields.items()):
             if isinstance(field, fields.BaseSubResourceField):
                 include_urls = include(field.get_related_resource().urls)
                 url_list += [
@@ -659,7 +661,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 del(kwargs_subset[key])
             except KeyError:
                 pass
-        for key, item in url_dict.iteritems():
+        for key, item in url_dict.items():
             if 'resource_name' in key or (key !='pk' and 'pk' in key):
                 try:
                     del (kwargs_subset[key])
@@ -1015,7 +1017,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         use_in = ['all', 'list' if for_list else 'detail']
 
         # Dehydrate each field.
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             # If it's not for use in this mode, skip
             field_use_in = getattr(field_object, 'use_in', 'all')
             if callable(field_use_in):
@@ -1064,7 +1066,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         bundle = self.hydrate(bundle)
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if field_object.readonly is True:
                 continue
 
@@ -1126,7 +1128,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if bundle.obj is None:
             raise HydrationError("You must call 'full_hydrate' before attempting to run 'hydrate_m2m' on %r." % self)
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_m2m', False):
                 continue
 
@@ -1144,7 +1146,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 if not (value is None and field_object.readonly):
                     bundle.data[field_name] = value
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_m2m', False):
                 continue
 
@@ -1180,7 +1182,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if self._meta.filtering:
             data['filtering'] = self._meta.filtering
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             data['fields'][field_name] = field_object.build_schema(field_name=field_name,resource_uri=self.get_resource_uri(), resource=self)
         return data
 
@@ -1206,7 +1208,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         """
         smooshed = []
 
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             smooshed.append("%s=%s" % (key, value))
 
         # Use a list plus a ``.join()`` because it's faster than concatenation.
@@ -1461,7 +1463,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         errors = self._meta.validation.is_valid(bundle, bundle.request) or {}
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_related', False):
                 #if its not a to one field or a m2m field or a subresource
                 continue
@@ -1921,7 +1923,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         Update the object in original_bundle in-place using new_data.
         """
         if hasattr(original_bundle.obj,'_prefetched_objects_cache'):
-            for key in new_data.keys():
+            for key in list(new_data.keys()):
                 if key in self._meta.prefetch_related:
                     field = self.fields.get(key)
                     try:
@@ -2257,7 +2259,7 @@ class BaseModelResource(Resource):
         else:
             query_terms = QUERY_TERMS
 
-        for filter_expr, value in filters.items():
+        for filter_expr, value in list(filters.items()):
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
             filter_type = 'exact'
@@ -2338,7 +2340,7 @@ class BaseModelResource(Resource):
     def build_exclude(self,request,filters):
         exclude_filters = {}
         notequal = '__ne'
-        for field, val in filters.items():
+        for field, val in list(filters.items()):
             if field.endswith(notequal):
                 exclude_filters[field[:-len(notequal)]]=val
                 filters.pop(field)
@@ -2369,7 +2371,7 @@ class BaseModelResource(Resource):
                 yield curr
 
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             # If it's not for use in this mode, skip
             field_use_in = getattr(field_object, 'use_in', 'all')
             if callable(field_use_in):
@@ -2453,7 +2455,7 @@ class BaseModelResource(Resource):
             object_list = self.get_object_list(bundle.request).filter(**kwargs)
             if optimize_query:
                 object_list = self.optimize_query(object_list, bundle)
-            stringified_kwargs = u", ".join([u"%s=%s" % (k, v) for k, v in kwargs.items()])
+            stringified_kwargs = u", ".join([u"%s=%s" % (k, v) for k, v in list(kwargs.items())])
 
             if len(object_list) <= 0:
                 raise self._meta.object_class.DoesNotExist("Couldn't find an instance of '%s' which matched '%s'." % (self._meta.object_class.__name__, stringified_kwargs))
@@ -2472,7 +2474,7 @@ class BaseModelResource(Resource):
         """
         bundle.obj = self._meta.object_class()
 
-        for key, value in kwargs.items():
+        for key, value in list(kwargs.items()):
             setattr(bundle.obj, key, value)
 
 
@@ -2632,7 +2634,7 @@ class BaseModelResource(Resource):
         '''
         Triggers change events on fields that are listening
         '''
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if field_object.readonly:
                 continue
 
@@ -2685,7 +2687,7 @@ class BaseModelResource(Resource):
         call ``save`` on them if they have related, non-M2M data.
         M2M data is handled by the ``ModelResource.save_m2m`` method.
         """
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_related', False):
                 continue
 
@@ -2752,7 +2754,7 @@ class BaseModelResource(Resource):
         Currently slightly inefficient in that it will clear out the whole
         relation and recreate the related data as needed.
         """
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_m2m', False):
                 continue
 
@@ -2894,7 +2896,7 @@ class MongoDBResource(Resource):
     NOTE: alter it f using obj_create and
     """
 
-    class Meta:
+    class Meta(object):
         pass
 
     def get_collection(self):
@@ -2921,7 +2923,7 @@ class MongoDBResource(Resource):
         filters = {}
 
         if hasattr(bundle.request, 'GET'):
-            filters = dict(bundle.request.GET.copy().iteritems())
+            filters = dict(iter(bundle.request.GET.copy().items()))
         # Update with the provided kwargs.
         if "format" in filters:
             del filters['format']

--- a/tastypie/response_dispatcher.py
+++ b/tastypie/response_dispatcher.py
@@ -1,3 +1,4 @@
+from builtins import object
 from tastypie import http
 from django.http import HttpResponse
 from django.utils.cache import patch_cache_control, patch_vary_headers

--- a/tastypie/response_router.py
+++ b/tastypie/response_router.py
@@ -1,3 +1,4 @@
+from builtins import object
 from tastypie.utils import get_request_class_name_lowered
 
 

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 import datetime
 import re
 import django
@@ -189,7 +190,7 @@ class Serializer(object):
         """
         desired_format = None
 
-        for short_format, long_format in self.content_types.items():
+        for short_format, long_format in list(self.content_types.items()):
             if format == long_format:
                 if hasattr(self, "to_%s" % short_format):
                     desired_format = short_format
@@ -210,7 +211,7 @@ class Serializer(object):
 
         format = format.split(';')[0]
 
-        for short_format, long_format in self.content_types.items():
+        for short_format, long_format in list(self.content_types.items()):
             if format == long_format:
                 if hasattr(self, "from_%s" % short_format):
                     desired_format = short_format
@@ -236,9 +237,9 @@ class Serializer(object):
         if isinstance(data, (list, tuple)):
             return [self.to_simple(item, options) for item in data]
         if isinstance(data, dict):
-            return dict((key, self.to_simple(val, options)) for (key, val) in data.items())
+            return dict((key, self.to_simple(val, options)) for (key, val) in list(data.items()))
         elif isinstance(data, Bundle):
-            return dict((key, self.to_simple(val, options)) for (key, val) in data.data.items())
+            return dict((key, self.to_simple(val, options)) for (key, val) in list(data.data.items()))
         elif hasattr(data, 'dehydrated_type'):
             if getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m == False:
                 if data.full:
@@ -288,12 +289,12 @@ class Serializer(object):
             else:
                 element = Element(name or 'object')
                 element.set('type', 'hash')
-            for (key, value) in data.items():
+            for (key, value) in list(data.items()):
                 element.append(self.to_etree(value, options, name=key, depth=depth+1))
                 element[:] = sorted(element, key=lambda x: x.tag)
         elif isinstance(data, Bundle):
             element = Element(name or 'object')
-            for field_name, field_object in data.data.items():
+            for field_name, field_object in list(data.data.items()):
                 element.append(self.to_etree(field_object, options, name=field_name, depth=depth+1))
                 element[:] = sorted(element, key=lambda x: x.tag)
         elif hasattr(data, 'dehydrated_type'):

--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -1,4 +1,8 @@
 from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import time
 
 from django.conf import settings
@@ -11,7 +15,7 @@ from tastypie.serializers import Serializer
 try:
     from urllib.parse import urlparse
 except ImportError:
-    from urlparse import urlparse
+    from urllib.parse import urlparse
 
 
 class TestApiClient(object):
@@ -309,7 +313,7 @@ class ResourceTestCase(TestCase):
             'oauth_timestamp': str(int(time.time())),
             'oauth_token': 'foo',
         }
-        return 'OAuth %s' % ','.join([key+'='+value for key, value in oauth_data.items()])
+        return 'OAuth %s' % ','.join([key+'='+value for key, value in list(oauth_data.items())])
 
     def assertHttpOK(self, resp):
         """

--- a/tastypie/throttle.py
+++ b/tastypie/throttle.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from builtins import object
 import time
 from django.core.cache import cache
 

--- a/tastypie/utils/dict.py
+++ b/tastypie/utils/dict.py
@@ -14,7 +14,7 @@ def dict_strip_unicode_keys(uni_dict):
 
     data = {}
 
-    for key, value in uni_dict.items():
+    for key, value in list(uni_dict.items()):
         data[smart_bytes(key)] = value
 
     return data

--- a/tastypie/utils/validate_jsonp.py
+++ b/tastypie/utils/validate_jsonp.py
@@ -5,6 +5,7 @@
 
 """Validate Javascript Identifiers for use as JSON-P callback parameters."""
 from __future__ import unicode_literals
+from builtins import chr
 import re
 
 from unicodedata import category
@@ -80,7 +81,7 @@ def is_valid_javascript_identifier(identifier, escape=r'\\u', ucd_cat=category):
             if len(segment) < 4:
                 return False
             try:
-                add_char(unichr(int('0x' + segment[:4], 16)))
+                add_char(chr(int('0x' + segment[:4], 16)))
             except Exception:
                 return False
             add_char(segment[4:])

--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+from past.builtins import basestring
+from builtins import object
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ModelForm
 from django.forms.models import model_to_dict

--- a/tests/alphanumeric/api/resources.py
+++ b/tests/alphanumeric/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from tastypie.authorization import Authorization
 from tastypie.fields import CharField
 from tastypie.resources import ModelResource
@@ -5,7 +6,7 @@ from alphanumeric.models import Product
 
 
 class ProductResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'products'
         queryset = Product.objects.all()
         authorization = Authorization()

--- a/tests/alphanumeric/tests/http.py
+++ b/tests/alphanumeric/tests/http.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import json
 from django.utils import six
 from testcases import TestServerTestCase
 
 try:
-    from http.client import HTTPConnection
+    from .http.client import HTTPConnection
 except ImportError:
     from httplib import HTTPConnection
 

--- a/tests/alphanumeric/tests/http.py
+++ b/tests/alphanumeric/tests/http.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import json
 from django.utils import six
 from testcases import TestServerTestCase
@@ -6,7 +8,7 @@ from testcases import TestServerTestCase
 try:
     from .http.client import HTTPConnection
 except ImportError:
-    from httplib import HTTPConnection
+    from http.client import HTTPConnection
 
 
 def header_name(name):

--- a/tests/authorization/api/resources.py
+++ b/tests/authorization/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
@@ -59,7 +60,7 @@ class PerUserAuthorization(Authorization):
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
         authentication = BasicAuthentication()
         authorization = Authorization()
@@ -67,7 +68,7 @@ class UserResource(ModelResource):
 
 
 class SiteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Site.objects.all()
         authentication = BasicAuthentication()
         authorization = Authorization()
@@ -77,7 +78,7 @@ class AuthorProfileResource(ModelResource):
     user = fields.ToOneField(UserResource, 'user', full=True)
     sites = fields.ToManyField(SiteResource, 'sites', related_name='author_profiles', full=True)
 
-    class Meta:
+    class Meta(object):
         queryset = AuthorProfile.objects.all()
         authentication = BasicAuthentication()
         authorization = Authorization()
@@ -86,7 +87,7 @@ class AuthorProfileResource(ModelResource):
 class ArticleResource(ModelResource):
     authors = fields.ToManyField(AuthorProfileResource, 'authors', related_name='articles', full=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Article.objects.all()
         authentication = BasicAuthentication()
         authorization = PerUserAuthorization()

--- a/tests/basic/api/resources.py
+++ b/tests/basic/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie.cache import SimpleCache
 from tastypie import fields
@@ -8,14 +9,14 @@ from basic.models import Note, AnnotatedNote, SlugBasedNote
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         authorization = Authorization()
 
 
 class CachedUserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         allowed_methods = ('get', )
         queryset = User.objects.all()
         resource_name = 'cached_users'
@@ -23,7 +24,7 @@ class CachedUserResource(ModelResource):
 
 
 class PublicCachedUserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         allowed_methods = ('get', )
         queryset = User.objects.all()
         resource_name = 'public_cached_users'
@@ -31,7 +32,7 @@ class PublicCachedUserResource(ModelResource):
 
 
 class PrivateCachedUserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         allowed_methods = ('get', )
         queryset = User.objects.all()
         resource_name = 'private_cached_users'
@@ -41,14 +42,14 @@ class PrivateCachedUserResource(ModelResource):
 class NoteResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'user')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()
 
 
 class BustedResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = AnnotatedNote.objects.all()
         resource_name = 'busted'
 
@@ -57,7 +58,7 @@ class BustedResource(ModelResource):
 
 
 class SlugBasedNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = SlugBasedNote.objects.all()
         resource_name = 'slugbased'
         detail_uri_name = 'slug'
@@ -65,7 +66,7 @@ class SlugBasedNoteResource(ModelResource):
 
 
 class SessionUserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'sessionusers'
         queryset = User.objects.all()
         authentication = SessionAuthentication()

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -1,3 +1,4 @@
+from builtins import object
 import datetime
 from django.contrib.auth.models import User
 from django.db import models
@@ -41,5 +42,5 @@ class SlugBasedNote(models.Model):
 
 
 class UserForm(forms.ModelForm):
-    class Meta:
+    class Meta(object):
         model = User

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 from testcases import TestServerTestCase
 import json
 from django.utils import six
 
 try:
-    from http.client import HTTPConnection
+    from .http.client import HTTPConnection
 except ImportError:
     from httplib import HTTPConnection
 

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from testcases import TestServerTestCase
 import json
 from django.utils import six
@@ -6,7 +8,7 @@ from django.utils import six
 try:
     from .http.client import HTTPConnection
 except ImportError:
-    from httplib import HTTPConnection
+    from http.client import HTTPConnection
 
 
 def header_name(name):

--- a/tests/basic/tests/resources.py
+++ b/tests/basic/tests/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import TestCase
@@ -11,39 +12,39 @@ from basic.models import Note, AnnotatedNote, SlugBasedNote
 class InvalidLazyUserResource(ModelResource):
     notes = ToManyField('basic.api.resources.FooResource', 'notes')
 
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
 
 
 class NoPathLazyUserResource(ModelResource):
     notes = ToManyField('FooResource', 'notes')
 
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
 
 
 class LazyUserResource(ModelResource):
     notes = ToManyField('basic.tests.resources.NoteResource', 'notes')
 
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
         api_name = 'foo'
 
 
 class NoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
 
 
 class AnnotatedNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = AnnotatedNote.objects.all()
 
 
 class NoteWithAnnotationsResource(ModelResource):
     annotated = ToOneField(AnnotatedNoteResource, 'annotated', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
 
 

--- a/tests/complex/api/resources.py
+++ b/tests/complex/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User, Group
 from django.contrib.comments.models import Comment
 from tastypie.fields import CharField, ForeignKey, ManyToManyField, OneToOneField, OneToManyField
@@ -6,19 +7,19 @@ from complex.models import Post, Profile
 
 
 class ProfileResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Profile.objects.all()
         resource_name = 'profiles'
 
 
 class CommentResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Comment.objects.all()
         resource_name = 'comments'
 
 
 class GroupResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Group.objects.all()
         resource_name = 'groups'
 
@@ -27,7 +28,7 @@ class UserResource(ModelResource):
     groups = ManyToManyField(GroupResource, 'groups', full=True)
     profile = OneToOneField(ProfileResource, 'profile', full=True)
     
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
         resource_name = 'users'
 
@@ -36,6 +37,6 @@ class PostResource(ModelResource):
     user = ForeignKey(UserResource, 'user')
     comments = OneToManyField(CommentResource, 'comments', full=False)
     
-    class Meta:
+    class Meta(object):
         queryset = Post.objects.all()
         resource_name = 'posts'

--- a/tests/content_gfk/api/resources.py
+++ b/tests/content_gfk/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from tastypie.authorization import Authorization
 from tastypie.contrib.contenttypes.fields import GenericForeignKeyField
 from tastypie.resources import ModelResource
@@ -6,20 +7,20 @@ from content_gfk.models import Note, Quote, Definition, Rating
 
 class DefinitionResource(ModelResource):
 
-    class Meta:
+    class Meta(object):
         resource_name = 'definitions'
         queryset = Definition.objects.all()
 
 class NoteResource(ModelResource):
 
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
 
 
 class QuoteResource(ModelResource):
 
-    class Meta:
+    class Meta(object):
         resource_name = 'quotes'
         queryset = Quote.objects.all()
 
@@ -29,7 +30,7 @@ class RatingResource(ModelResource):
         Quote: QuoteResource
     }, 'content_object')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'ratings'
         queryset = Rating.objects.all()
         authorization = Authorization()

--- a/tests/content_gfk/models.py
+++ b/tests/content_gfk/models.py
@@ -1,3 +1,4 @@
+from builtins import range
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic

--- a/tests/core/forms.py
+++ b/tests/core/forms.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django import forms
 from core.models import Note
 
@@ -5,12 +6,12 @@ from core.models import Note
 class NoteForm(forms.ModelForm):
     foobaz = forms.CharField()
     
-    class Meta:
+    class Meta(object):
         model = Note
 
 
 class VeryCustomNoteForm(NoteForm):
-    class Meta:
+    class Meta(object):
         model = Note
         fields = ['title', 'content', 'created', 'is_active', 'foobaz']
 

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import TestCase
@@ -9,13 +10,13 @@ from core.models import Note
 
 
 class NoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
 

--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -1,3 +1,4 @@
+from builtins import str
 import base64
 import os
 import time
@@ -434,7 +435,7 @@ class OAuthAuthenticationTestCase(TestCase):
             'oauth_timestamp': str(int(time.time())),
             'oauth_token': 'foo',
         }
-        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in self.request.REQUEST.items()])
+        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in list(self.request.REQUEST.items())])
         resp = auth.is_authenticated(self.request)
         self.assertEqual(resp, True)
         self.assertEqual(self.request.user.pk, self.user.pk)
@@ -451,7 +452,7 @@ class OAuthAuthenticationTestCase(TestCase):
             'oauth_timestamp': str(int(time.time())),
             'oauth_token': 'bar',
         }
-        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in self.request.REQUEST.items()])
+        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in list(self.request.REQUEST.items())])
         resp = auth.is_authenticated(self.request)
         self.assertFalse(resp)
 
@@ -467,7 +468,7 @@ class OAuthAuthenticationTestCase(TestCase):
             'oauth_timestamp': str(int(time.time())),
             'oauth_token': 'bar',
         }
-        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in self.request.REQUEST.items()])
+        self.request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in list(self.request.REQUEST.items())])
         resp = auth.is_authenticated(self.request)
         self.assertTrue(resp)
         self.assertEqual(self.request.user.pk, self.user_inactive.pk)

--- a/tests/core/tests/authorization.py
+++ b/tests/core/tests/authorization.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.test import TestCase
 from django.http import HttpRequest
 from django.contrib.auth.models import User, Permission
@@ -9,21 +10,21 @@ from tastypie.resources import Resource, ModelResource
 
 
 class NoRulesNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
         authorization = Authorization()
 
 
 class ReadOnlyNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
         authorization = ReadOnlyAuthorization()
 
 
 class DjangoNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
         authorization = DjangoAuthorization()
@@ -36,7 +37,7 @@ class NotAModel(object):
 class NotAModelResource(Resource):
     name = fields.CharField(attribute='name')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'notamodel'
         object_class = NotAModel
         authorization = DjangoAuthorization()

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -1,3 +1,4 @@
+from builtins import object
 try:
     from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
@@ -9,7 +10,7 @@ from core.tests.api import Api, UserResource
 
 
 class SubjectResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'subjects'
         queryset = Subject.objects.all()
 
@@ -18,7 +19,7 @@ class CustomNoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author')
     subjects = fields.ManyToManyField(SubjectResource, 'subjects')
     
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
 

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -1,3 +1,4 @@
+from builtins import object
 import datetime
 from dateutil.tz import *
 from django.db import models
@@ -594,7 +595,7 @@ class DateTimeFieldTestCase(TestCase):
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
 
@@ -909,7 +910,7 @@ class ToOneFieldTestCase(TestCase):
 
 
 class SubjectResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'subjects'
         queryset = Subject.objects.all()
 
@@ -921,7 +922,7 @@ class SubjectResource(ModelResource):
 
 
 class MediaBitResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'mediabits'
         queryset = MediaBit.objects.all()
 

--- a/tests/core/tests/mocks.py
+++ b/tests/core/tests/mocks.py
@@ -1,3 +1,4 @@
+from builtins import object
 import django
 
 class MockRequest(object):

--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from builtins import str
 from django.conf import settings
 from django.test import TestCase
 from tastypie.exceptions import BadRequest

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import base64
 import copy
 import datetime
@@ -69,7 +71,7 @@ class BasicResourceWithDifferentListAndDetailFields(Resource):
         test_object_1.date_joined = aware_datetime(2010, 3, 30, 9, 0, 0)
         return [test_object_1]
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'basic'
 
@@ -79,7 +81,7 @@ class BasicResourceWithDifferentListAndDetailFieldsCallable(Resource):
     view_count = fields.IntegerField(attribute='view_count', default=0, use_in=lambda x,y: True)
     date_joined = fields.DateTimeField(null=True, use_in=lambda x,y: False)
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'basic'
 
@@ -89,7 +91,7 @@ class BasicResource(Resource):
     view_count = fields.IntegerField(attribute='view_count', default=0)
     date_joined = fields.DateTimeField(null=True)
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'basic'
         authorization = Authorization()
@@ -120,7 +122,7 @@ class AnotherBasicResource(BasicResource):
     meta = fields.DictField(attribute='metadata', null=True)
     owed = fields.DecimalField(attribute='money_owed', null=True)
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'anotherbasic'
         authorization = Authorization()
@@ -146,7 +148,7 @@ class NoUriBasicResource(BasicResource):
     view_count = fields.IntegerField(attribute='view_count', default=0)
     date_joined = fields.DateTimeField(null=True)
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         include_resource_uri = False
         authorization = Authorization()
@@ -155,14 +157,14 @@ class NoUriBasicResource(BasicResource):
 class NullableNameResource(Resource):
     name = fields.CharField(attribute='name', null=True)
 
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'nullable_name'
         authorization = Authorization()
 
 
 class MangledBasicResource(BasicResource):
-    class Meta:
+    class Meta(object):
         object_class = TestObject
         resource_name = 'mangledbasic'
         authorization = Authorization()
@@ -556,7 +558,7 @@ class ResourceTestCase(TestCase):
         self.assertRaises(NotImplementedError, basic.rollback, bundles_seen)
 
     def adjust_schema(self, schema_dict):
-        for field, field_info in schema_dict['fields'].items():
+        for field, field_info in list(schema_dict['fields'].items()):
             if isinstance(field_info['default'], fields.NOT_PROVIDED):
                 schema_dict['fields'][field]['default'] = 'No default provided.'
 
@@ -665,14 +667,14 @@ class ResourceTestCase(TestCase):
         })
 
     def test_subclassing(self):
-        class CommonMeta:
+        class CommonMeta(object):
             default_format = 'application/xml'
 
         class MiniResource(Resource):
             abcd = fields.CharField(default='abcd')
             efgh = fields.IntegerField(default=1234)
 
-            class Meta:
+            class Meta(object):
                 resource_name = 'mini'
 
         mini = MiniResource()
@@ -800,7 +802,7 @@ class ResourceTestCase(TestCase):
 # ====================
 
 class DateRecordResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = DateRecord.objects.all()
         always_return_data = True
         authorization = Authorization()
@@ -815,7 +817,7 @@ class DateRecordResource(ModelResource):
 
 
 class NoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         authorization = Authorization()
         filtering = {
@@ -834,7 +836,7 @@ class NoteResource(ModelResource):
         return '/api/v1/notes/%s/' % bundle_or_obj.obj.id
 
 class NoQuerysetNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'noqsnotes'
         authorization = Authorization()
         filtering = {
@@ -844,7 +846,7 @@ class NoQuerysetNoteResource(ModelResource):
 
 
 class LightlyCustomNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'noteish'
         authorization = Authorization()
         allowed_methods = ['get']
@@ -852,7 +854,7 @@ class LightlyCustomNoteResource(NoteResource):
 
 
 class TinyLimitNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         limit = 3
         resource_name = 'littlenote'
         authorization = Authorization()
@@ -861,7 +863,7 @@ class TinyLimitNoteResource(NoteResource):
 
 
 class AlwaysDataNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'alwaysdatanote'
         queryset = Note.objects.filter(is_active=True)
         always_return_data = True
@@ -872,7 +874,7 @@ class AlwaysDataNoteResourceUseIn(NoteResource):
     author = fields.CharField(attribute='author__username', use_in="detail")
     constant = fields.IntegerField(default=20, use_in="list")
 
-    class Meta:
+    class Meta(object):
         resource_name = 'alwaysdatanote'
         queryset = Note.objects.filter(is_active=True)
         always_return_data = True
@@ -883,7 +885,7 @@ class VeryCustomNoteResource(NoteResource):
     author = fields.CharField(attribute='author__username')
     constant = fields.IntegerField(default=20)
 
-    class Meta:
+    class Meta(object):
         authorization = Authorization()
         limit = 50
         resource_name = 'notey'
@@ -895,7 +897,7 @@ class VeryCustomNoteResource(NoteResource):
 
 
 class AutoNowNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'autonownotes'
         queryset = AutoNowNote.objects.filter(is_active=True)
         authorization = Authorization()
@@ -915,7 +917,7 @@ class CustomPaginator(Paginator):
 
 
 class CustomPageNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         limit = 10
         resource_name = 'pagey'
         paginator_class = CustomPaginator
@@ -924,7 +926,7 @@ class CustomPageNoteResource(NoteResource):
 
 
 class AlwaysUserNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'noteish'
         queryset = Note.objects.filter(is_active=True)
         authorization = Authorization()
@@ -937,12 +939,12 @@ class UseInNoteResource(NoteResource):
     content = fields.CharField(attribute='content', use_in='detail')
     title = fields.CharField(attribute='title', use_in='list')
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         authorization = Authorization()
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = User.objects.all()
         authorization = Authorization()
 
@@ -957,7 +959,7 @@ class DetailedNoteResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'author')
     hello_world = fields.CharField(default='world')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'detailednotes'
         filtering = {
             'content': ['startswith', 'exact'],
@@ -984,14 +986,14 @@ class DetailedNoteResourceWithHydrate(DetailedNoteResource):
 class RequiredFKNoteResource(ModelResource):
     editor = fields.ForeignKey(UserResource, 'editor')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'requiredfknotes'
         queryset = NoteWithEditor.objects.all()
         authorization = Authorization()
 
 
 class ThrottledNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'throttlednotes'
         queryset = Note.objects.filter(is_active=True)
         throttle = CacheThrottle(throttle_at=2, timeframe=5, expiration=5)
@@ -999,7 +1001,7 @@ class ThrottledNoteResource(NoteResource):
 
 
 class BasicAuthNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
         authentication = BasicAuthentication()
@@ -1007,14 +1009,14 @@ class BasicAuthNoteResource(NoteResource):
 
 
 class NoUriNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.filter(is_active=True)
         include_resource_uri = False
         authorization = Authorization()
 
 
 class WithAbsoluteURLNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.filter(is_active=True)
         include_absolute_url = True
         resource_name = 'withabsoluteurlnote'
@@ -1028,14 +1030,14 @@ class WithAbsoluteURLNoteResource(ModelResource):
 
 
 class AlternativeCollectionNameNoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.filter(is_active=True)
         collection_name = 'alt_objects'
         authorization = Authorization()
 
 
 class SubjectResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Subject.objects.all()
         resource_name = 'subjects'
         filtering = {
@@ -1048,7 +1050,7 @@ class RelatedNoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author')
     subjects = fields.ManyToManyField(SubjectResource, 'subjects')
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         resource_name = 'relatednotes'
         filtering = {
@@ -1062,7 +1064,7 @@ class RelatedNoteResource(ModelResource):
 class AnotherSubjectResource(ModelResource):
     notes = fields.ToManyField(DetailedNoteResource, 'notes')
 
-    class Meta:
+    class Meta(object):
         queryset = Subject.objects.all()
         resource_name = 'anothersubjects'
         excludes = ['notes']
@@ -1076,7 +1078,7 @@ class AnotherRelatedNoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author')
     subjects = fields.ManyToManyField(SubjectResource, 'subjects', full=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         resource_name = 'relatednotes'
         filtering = {
@@ -1091,7 +1093,7 @@ class YetAnotherRelatedNoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author', full=True)
     subjects = fields.ManyToManyField(SubjectResource, 'subjects')
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         resource_name = 'relatednotes'
         filtering = {
@@ -1111,7 +1113,7 @@ class NullableMediaBitResource(ModelResource):
     # The old (broke) way to allow ``note`` to be omitted, even though it's a required field.
     note = fields.ToOneField(NoteResource, 'note', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = MediaBit.objects.all()
         resource_name = 'nullablemediabit'
         authorization = Authorization()
@@ -1121,7 +1123,7 @@ class ReadOnlyRelatedNoteResource(ModelResource):
     author = fields.ToOneField(UserResource, 'author', readonly=True)
     my_property = fields.CharField(attribute='my_property', null=True, readonly=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         authorization = Authorization()
 
@@ -1130,7 +1132,7 @@ class BlankMediaBitResource(ModelResource):
     # Allow ``note`` to be omitted, even though it's a required field.
     note = fields.ToOneField(NoteResource, 'note', blank=True)
 
-    class Meta:
+    class Meta(object):
         queryset = MediaBit.objects.all()
         resource_name = 'blankmediabit'
         authorization = Authorization()
@@ -1147,7 +1149,7 @@ class BlankMediaBitResource(ModelResource):
 
 
 class TestOptionsResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         allowed_methods = ['post']
         list_allowed_methods = ['post', 'put']
@@ -1167,7 +1169,7 @@ class PerUserAuthorization(Authorization):
 
 
 class PerUserNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'perusernotes'
         queryset = Note.objects.all()
         authorization = PerUserAuthorization()
@@ -1207,7 +1209,7 @@ class PerObjectAuthorization(Authorization):
 
 
 class PerObjectNoteResource(NoteResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'perobjectnotes'
         queryset = Note.objects.all()
         authorization = PerObjectAuthorization()
@@ -1232,7 +1234,7 @@ class PerObjectNoteResource(NoteResource):
 class CounterResource(ModelResource):
     count = fields.IntegerField('count', default=0, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Counter.objects.all()
         authorization = Authorization()
 
@@ -1256,7 +1258,7 @@ class CounterAuthorization(Authorization):
 class CounterCreateDetailResource(ModelResource):
     count = fields.IntegerField('count', default=0, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Counter.objects.all()
         authorization = CounterAuthorization()
 
@@ -1264,7 +1266,7 @@ class CounterCreateDetailResource(ModelResource):
 class CounterUpdateDetailResource(ModelResource):
     count = fields.IntegerField('count', default=0, null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Counter.objects.all()
         authorization = CounterAuthorization()
 
@@ -1574,7 +1576,7 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(resource.determine_format(request), 'application/xml')
 
     def adjust_schema(self, schema_dict):
-        for field, field_info in schema_dict['fields'].items():
+        for field, field_info in list(schema_dict['fields'].items()):
             if isinstance(field_info['default'], fields.NOT_PROVIDED):
                 schema_dict['fields'][field]['default'] = 'No default provided.'
             if isinstance(field_info['default'], (datetime.datetime, datetime.date)):
@@ -2206,7 +2208,7 @@ class ModelResourceTestCase(TestCase):
         resp = resource.wrap_view('get_list')(request)
         self.assertEqual(resp.status_code, 400)
         res = json.loads(resp.content.decode('utf-8'))
-        self.assertTrue('error' in res.keys())
+        self.assertTrue('error' in list(res.keys()))
         self.assertTrue('monkey' in res['error']) #Error looks like "No matching \'monkey\' field for ordering on.
 
         # Test to make sure we're not inadvertently caching the QuerySet.
@@ -3270,7 +3272,7 @@ class ModelResourceTestCase(TestCase):
 
     def test_obj_delete_list_non_queryset(self):
         class NonQuerysetNoteResource(ModelResource):
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
 
             def authorized_delete_list(self, object_list, bundle):
@@ -3607,13 +3609,13 @@ class ModelResourceTestCase(TestCase):
                 return self.cleaned_data
 
         class ValidatedNoteResource(ModelResource):
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'validated'
                 validation = FormValidation(form_class=NoteForm)
 
         class ValidatedXMLNoteResource(ModelResource):
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'validated'
                 validation = FormValidation(form_class=NoteForm)
@@ -3651,7 +3653,7 @@ class ModelResourceTestCase(TestCase):
         class SelfResource(ModelResource):
             me_baby_me = fields.ToOneField('self', 'parent', null=True)
 
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'me_baby_me'
 
@@ -3662,7 +3664,7 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(me_baby_me.fields['me_baby_me'].to_class, SelfResource)
 
         class AnotherSelfResource(SelfResource):
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'another_me_baby_me'
 
@@ -3677,7 +3679,7 @@ class ModelResourceTestCase(TestCase):
             abcd = fields.CharField(default='abcd')
             efgh = fields.IntegerField(default=1234)
 
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'mini'
 
@@ -3689,7 +3691,7 @@ class ModelResourceTestCase(TestCase):
         class AnotherMiniResource(MiniResource):
             ijkl = fields.BooleanField(default=True)
 
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'anothermini'
 
@@ -3701,7 +3703,7 @@ class ModelResourceTestCase(TestCase):
         class YetAnotherMiniResource(MiniResource):
             mnop = fields.FloatField(default=True)
 
-            class Meta:
+            class Meta(object):
                 queryset = Note.objects.all()
                 resource_name = 'yetanothermini'
                 fields = ['title', 'abcd', 'mnop']
@@ -4181,7 +4183,7 @@ class BustedResourceTestCase(TestCase):
 class ObjectlessResource(Resource):
     test = fields.CharField(default='objectless_test')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'objectless'
 
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -700,7 +700,7 @@ class ResourceTestCase(TestCase):
         try:
             basic.method_check(request)
             self.fail("Should have thrown an exception.")
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response['Allow'], '')
 
         # Not an allowed request.
@@ -709,7 +709,7 @@ class ResourceTestCase(TestCase):
         try:
             basic.method_check(request, allowed=['post'])
             self.fail("Should have thrown an exception.")
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response['Allow'], 'POST')
 
         # Allowed (single).
@@ -733,7 +733,7 @@ class ResourceTestCase(TestCase):
         try:
             basic.method_check(request, allowed=['get', 'put', 'delete', 'patch'])
             self.fail("Should have thrown an exception.")
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response['Allow'], 'GET,PUT,DELETE,PATCH')
 
         # Allowed (multiple).
@@ -3195,7 +3195,7 @@ class ModelResourceTestCase(TestCase):
         try:
             resp = resource.dispatch('list', request)
             self.fail()
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response.status_code, 429)
             self.assertEqual(len(cache.get('noaddr_nohost_accesses')), 2)
 
@@ -3203,7 +3203,7 @@ class ModelResourceTestCase(TestCase):
         try:
             resp = resource.dispatch('list', request)
             self.fail()
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response.status_code, 429)
             self.assertEqual(len(cache.get('noaddr_nohost_accesses')), 2)
 
@@ -4017,7 +4017,7 @@ class BasicAuthResourceTestCase(TestCase):
         try:
             resp = resource.dispatch_list(request)
             self.fail()
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response.status_code, 401)
 
         # Try again with ``wrap_view`` for sanity.
@@ -4041,7 +4041,7 @@ class BasicAuthResourceTestCase(TestCase):
         try:
             resp = resource.dispatch_detail(request, pk=1)
             self.fail()
-        except ImmediateResponse, e:
+        except ImmediateResponse as e:
             self.assertEqual(e.response.status_code, 401)
 
         # Try again with ``wrap_view`` for sanity.

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from builtins import object
 import datetime
 import yaml
 from decimal import Decimal
@@ -23,7 +24,7 @@ class UnsafeObject(object):
 
 
 class NoteResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
 
@@ -33,7 +34,7 @@ class AnotherNoteResource(ModelResource):
     meta = fields.DictField(attribute='metadata', null=True)
     owed = fields.DecimalField(attribute='money_owed', null=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'anothernotes'
         queryset = Note.objects.filter(is_active=True)
 

--- a/tests/gis/api/resources.py
+++ b/tests/gis/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.resources import ALL
@@ -7,7 +8,7 @@ from gis.models import GeoNote
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         authorization = Authorization()
@@ -16,7 +17,7 @@ class UserResource(ModelResource):
 class GeoNoteResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'user')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'geonotes'
         queryset = GeoNote.objects.all()
         authorization = Authorization()

--- a/tests/gis/tests/http.py
+++ b/tests/gis/tests/http.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 from testcases import TestServerTestCase
 import json
 
 try:
-    from http.client import HTTPConnection
+    from .http.client import HTTPConnection
 except ImportError:
     from httplib import HTTPConnection
 

--- a/tests/gis/tests/http.py
+++ b/tests/gis/tests/http.py
@@ -1,16 +1,18 @@
 from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from testcases import TestServerTestCase
 import json
 
 try:
     from .http.client import HTTPConnection
 except ImportError:
-    from httplib import HTTPConnection
+    from http.client import HTTPConnection
 
 try:
     from urllib.parse import quote
 except ImportError:
-    from urllib import quote
+    from urllib.parse import quote
 
 
 class HTTPTestCase(TestServerTestCase):

--- a/tests/manage_authorization.py
+++ b/tests/manage_authorization.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_authorization as settings
+    from . import settings_authorization as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_authorization.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_basic.py
+++ b/tests/manage_basic.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_basic as settings
+    from . import settings_basic as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_basic.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_complex.py
+++ b/tests/manage_complex.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_complex as settings
+    from . import settings_complex as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_complex.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_contenttypes.py
+++ b/tests/manage_contenttypes.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_content_gfk as settings
+    from . import settings_content_gfk as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_contenttypes.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_core.py
+++ b/tests/manage_core.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_core as settings
+    from . import settings_core as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_core.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_customuser.py
+++ b/tests/manage_customuser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_core as settings
+    from . import settings_core as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_core.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_gis.py
+++ b/tests/manage_gis.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_gis as settings
+    from . import settings_gis as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_gis.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_namespaced.py
+++ b/tests/manage_namespaced.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_namespaced as settings
+    from . import settings_namespaced as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_namespaced.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_related.py
+++ b/tests/manage_related.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_related as settings
+    from . import settings_related as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_related.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_slashless.py
+++ b/tests/manage_slashless.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_slashless as settings
+    from . import settings_slashless as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_slashless.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/manage_validation.py
+++ b/tests/manage_validation.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os
 import sys
 
@@ -7,7 +8,7 @@ from os.path import abspath, dirname, join
 from django.core.management import execute_manager
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 try:
-    import settings_validation as settings
+    from . import settings_validation as settings
 except ImportError:
     import sys
     sys.stderr.write("Error: Can't find the file 'settings_basic.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)

--- a/tests/namespaced/api/resources.py
+++ b/tests/namespaced/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.resources import ModelResource, NamespacedModelResource
@@ -6,7 +7,7 @@ from basic.models import Note
 
 
 class NamespacedUserResource(NamespacedModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         authorization = Authorization()
@@ -15,7 +16,7 @@ class NamespacedUserResource(NamespacedModelResource):
 class NamespacedNoteResource(NamespacedModelResource):
     user = fields.ForeignKey(NamespacedUserResource, 'user')
     
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.resources import ModelResource
@@ -9,7 +10,7 @@ from tests.related_resource.models import Label, Post
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         allowed_methods = ['get']
@@ -19,7 +20,7 @@ class UserResource(ModelResource):
 class NoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author')
 
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()
@@ -28,7 +29,7 @@ class NoteResource(ModelResource):
 class CategoryResource(ModelResource):
     parent = fields.ToOneField('self', 'parent', null=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'category'
         queryset = Category.objects.all()
         authorization = Authorization()
@@ -43,7 +44,7 @@ class TagResource(ModelResource):
             'related_resource.api.resources.ExtraDataResource', 'extradata',
             null=True, blank=True, full=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'tag'
         queryset = Tag.objects.all()
         authorization = Authorization()
@@ -54,7 +55,7 @@ class TaggableResource(ModelResource):
             'related_resource.api.resources.TaggableTagResource', 'taggabletags',
             null=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'taggable'
         queryset = Taggable.objects.all()
         authorization = Authorization()
@@ -68,7 +69,7 @@ class TaggableTagResource(ModelResource):
             'related_resource.api.resources.TaggableResource', 'taggable',
             null=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'taggabletag'
         queryset = TaggableTag.objects.all()
         authorization = Authorization()
@@ -79,7 +80,7 @@ class ExtraDataResource(ModelResource):
             'related_resource.api.resources.TagResource', 'tag',
             null=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'extradata'
         queryset = ExtraData.objects.all()
         authorization = Authorization()
@@ -88,7 +89,7 @@ class ExtraDataResource(ModelResource):
 class FreshNoteResource(ModelResource):
     media_bits = fields.ToManyField('related_resource.api.resources.FreshMediaBitResource', 'media_bits', related_name='note')
 
-    class Meta:
+    class Meta(object):
         queryset = Note.objects.all()
         resource_name = 'freshnote'
         authorization = Authorization()
@@ -97,14 +98,14 @@ class FreshNoteResource(ModelResource):
 class FreshMediaBitResource(ModelResource):
     note = fields.ToOneField(FreshNoteResource, 'note')
 
-    class Meta:
+    class Meta(object):
         queryset = MediaBit.objects.all()
         resource_name = 'freshmediabit'
         authorization = Authorization()
 
 
 class AddressResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = Address.objects.all()
         resource_name = 'address'
         authorization = Authorization()
@@ -113,7 +114,7 @@ class AddressResource(ModelResource):
 class ProductResource(ModelResource):
     producer = fields.ToOneField('related_resource.api.resources.CompanyResource', 'producer')
 
-    class Meta:
+    class Meta(object):
         queryset = Product.objects.all()
         resource_name = 'product'
         authorization = Authorization()
@@ -123,7 +124,7 @@ class CompanyResource(ModelResource):
     address = fields.ToOneField(AddressResource, 'address', null=True, full=True)
     products = fields.ToManyField(ProductResource, 'products', full=True, related_name='producer', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Company.objects.all()
         resource_name = 'company'
         authorization = Authorization()
@@ -133,14 +134,14 @@ class PersonResource(ModelResource):
     company = fields.ToOneField(CompanyResource, 'company', null=True, full=True)
     dogs = fields.ToManyField('related_resource.api.resources.DogResource', 'dogs', full=True, related_name='owner', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Person.objects.all()
         resource_name = 'person'
         authorization = Authorization()
 
 
 class DogHouseResource(ModelResource):
-    class Meta:
+    class Meta(object):
         queryset = DogHouse.objects.all()
         resource_name = 'doghouse'
         authorization = Authorization()
@@ -149,7 +150,7 @@ class DogHouseResource(ModelResource):
 class BoneResource(ModelResource):
     dog = fields.ToOneField('related_resource.api.resources.DogResource', 'dog')
 
-    class Meta:
+    class Meta(object):
         queryset = Bone.objects.all()
         resource_name = 'bone'
         authorization = Authorization()
@@ -160,13 +161,13 @@ class DogResource(ModelResource):
     house = fields.ToOneField(DogHouseResource, 'house', full=True, null=True)
     bones = fields.ToManyField(BoneResource, 'bones', full=True, null=True, related_name='dog')
 
-    class Meta:
+    class Meta(object):
         queryset = Dog.objects.all()
         resource_name = 'dog'
         authorization = Authorization()
 
 class LabelResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'label'
         queryset = Label.objects.all()
         authorization = Authorization()
@@ -175,7 +176,7 @@ class LabelResource(ModelResource):
 class PostResource(ModelResource):
     label = fields.ToManyField(LabelResource, 'label', null=True)
 
-    class Meta:
+    class Meta(object):
         queryset = Post.objects.all()
         resource_name = 'post'
         authorization = Authorization()
@@ -183,7 +184,7 @@ class PostResource(ModelResource):
 class PaymentResource(ModelResource):
     job = fields.ToOneField('related_resource.api.resources.JobResource', 'job')
 
-    class Meta:
+    class Meta(object):
         queryset = Payment.objects.all()
         resource_name = 'payment'
         authorization = Authorization()
@@ -192,7 +193,7 @@ class PaymentResource(ModelResource):
 class JobResource(ModelResource):
     payment = fields.ToOneField(PaymentResource, 'payment', related_name='job')
 
-    class Meta:
+    class Meta(object):
         queryset = Job.objects.all()
         resource_name = 'job'
         authorization = Authorization()

--- a/tests/settings_alphanumeric.py
+++ b/tests/settings_alphanumeric.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('alphanumeric')
 
 ROOT_URLCONF = 'alphanumeric.urls'

--- a/tests/settings_authorization.py
+++ b/tests/settings_authorization.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 
 INSTALLED_APPS.append('django.contrib.sites')
 INSTALLED_APPS.append('authorization')

--- a/tests/settings_basic.py
+++ b/tests/settings_basic.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('django.contrib.sessions')
 INSTALLED_APPS.append('basic')
 

--- a/tests/settings_complex.py
+++ b/tests/settings_complex.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 
 INSTALLED_APPS += [
     'complex',

--- a/tests/settings_content_gfk.py
+++ b/tests/settings_content_gfk.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 
 INSTALLED_APPS += [
     'content_gfk',

--- a/tests/settings_core.py
+++ b/tests/settings_core.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('django.contrib.sessions')
 INSTALLED_APPS.append('core')
 

--- a/tests/settings_customuser.py
+++ b/tests/settings_customuser.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('customuser')
 INSTALLED_APPS.append('django.contrib.auth')
 

--- a/tests/settings_gis.py
+++ b/tests/settings_gis.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('gis')
 
 # We just hardcode postgis here.

--- a/tests/settings_namespaced.py
+++ b/tests/settings_namespaced.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('basic')
 INSTALLED_APPS.append('namespaced')
 

--- a/tests/settings_related.py
+++ b/tests/settings_related.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('core')
 INSTALLED_APPS.append('related_resource')
 

--- a/tests/settings_slashless.py
+++ b/tests/settings_slashless.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('basic')
 INSTALLED_APPS.append('slashless')
 

--- a/tests/settings_validation.py
+++ b/tests/settings_validation.py
@@ -1,4 +1,5 @@
-from settings import *
+from __future__ import absolute_import
+from .settings import *
 INSTALLED_APPS.append('basic')
 INSTALLED_APPS.append('validation')
 

--- a/tests/slashless/api/resources.py
+++ b/tests/slashless/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.resources import ModelResource
@@ -6,7 +7,7 @@ from basic.models import Note
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         authorization = Authorization()
@@ -15,7 +16,7 @@ class UserResource(ModelResource):
 class NoteResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'user')
     
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()

--- a/tests/validation/api/resources.py
+++ b/tests/validation/api/resources.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.constants import ALL
@@ -12,7 +13,7 @@ from tastypie.validation import FormValidation
 
 
 class UserResource(ModelResource):
-    class Meta:
+    class Meta(object):
         resource_name = 'users'
         queryset = User.objects.all()
         authorization = Authorization()
@@ -20,13 +21,13 @@ class UserResource(ModelResource):
 
 class AnnotatedNoteForm(forms.ModelForm):
 
-    class Meta:
+    class Meta(object):
         model = AnnotatedNote
         exclude = ('note',)
 
 class AnnotatedNoteResource(ModelResource):
 
-    class Meta:
+    class Meta(object):
         resource_name = 'annotated'
         queryset = AnnotatedNote.objects.all()
         authorization = Authorization()
@@ -34,7 +35,7 @@ class AnnotatedNoteResource(ModelResource):
 
 class NoteForm(forms.ModelForm):
 
-    class Meta:
+    class Meta(object):
         model = Note
         exclude = ('user', 'created', 'updated')
 
@@ -42,7 +43,7 @@ class NoteResource(ModelResource):
     user = fields.ForeignKey(UserResource, 'user')
     annotated = fields.ForeignKey(AnnotatedNoteResource, 'annotated', related_name='note', null=True, full=True)
 
-    class Meta:
+    class Meta(object):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()


### PR DESCRIPTION
Run `futurize` `stage-1` and `stage-2` to update code with py2/3 compatibility. We will merge this after approval, then version a new release for this project, use it in the `requirements.txt` of `recruiterbox` and deploy it to smoke to test out. There will be basically three levels of testing here:

1) Running the tastypie test suite to see that all tests still pass. (I'm currently testing it out on local)
2) Running the recruiterbox test suite with these changes to see that all tests still pass.
3) Some manual testing on tastypie related resources on smoketest.

Since our machines aren't currently running `python3.x` (we have `python3.7` installed but haven't switched it to default yet so all the code is still running in `python2.7` interpreter) we don't need to run the test suite in `python3.x`. We can eventually do this with `tox` (https://tox.readthedocs.io/en/latest/) and integrate it with our CI so that we don't break 2/3 compatibility.

