### PR TITLE
Separate out relation and query term lookups while validating filter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='django-tastypie',
-    version='0.17.0',
+    version='0.18.0',
     description='A flexible & capable API layer for Django.',
     author='Daniel Lindsley',
     author_email='daniel@toastdriven.com',

--- a/tastypie/__init__.py
+++ b/tastypie/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 
 __author__ = 'Daniel Lindsley & the Tastypie core team'
-__version__ = (0, 11, 9, 'dev')
+__version__ = (0, 18, 0, 'dev')
 
 from django.core.handlers.wsgi import WSGIRequest
 from .response_dispatcher import HttpResponseDispatcher

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2178,7 +2178,7 @@ class BaseModelResource(Resource):
             raise InvalidFilterError("The '%s' field does not allow filtering." % field_name)
 
         # Check to see if it's an allowed lookup type.
-        if not self._meta.filtering[field_name] in (ALL, ALL_WITH_RELATIONS):
+        if filter_type != "exact" and not self._meta.filtering[field_name] in (ALL, ALL_WITH_RELATIONS):
             # Must be an explicit whitelist.
             if not filter_type in self._meta.filtering[field_name]:
                 raise InvalidFilterError("'%s' is not an allowed filter on the '%s' field." % (filter_type, field_name))
@@ -2186,8 +2186,14 @@ class BaseModelResource(Resource):
         if self.fields[field_name].attribute is None:
             raise InvalidFilterError("The '%s' field has no 'attribute' for searching with." % field_name)
 
-        # Check to see if it's a relational lookup and if that's allowed.
-        if len(filter_bits):
+        if len(filter_bits) == 0:
+            # Only a field provided, match with provided filter type
+            return [self.fields[field_name].attribute] + [filter_type]
+        elif len(filter_bits) == 1 and filter_bits[0] in self.get_query_terms(field_name):
+            # Match with valid filter type (i.e. contains, startswith, Etc.)
+            return [self.fields[field_name].attribute] + filter_bits
+        else:
+            # Check to see if it's a relational lookup and if that's allowed.
             if not getattr(self.fields[field_name], 'is_related', False):
                 raise InvalidFilterError("The '%s' field does not support relations." % field_name)
 
@@ -2198,9 +2204,41 @@ class BaseModelResource(Resource):
             # if any. We should ensure that all along the way, we're allowed
             # to filter on that field by the related resource.
             related_resource = self.fields[field_name].get_related_resource(None)
-            return [self.fields[field_name].attribute] + related_resource.check_filtering(filter_bits[0], filter_type, filter_bits[1:])
+            next_field_name = filter_bits[0]
+            next_filter_bits = filter_bits[1:]
+            next_filter_type = related_resource.resolve_filter_type(next_field_name, next_filter_bits, filter_type)
 
-        return [self.fields[field_name].attribute]
+            return [self.fields[field_name].attribute] + related_resource.check_filtering(next_field_name,
+                                                                                          next_filter_type,
+                                                                                          next_filter_bits)
+
+    def get_query_terms(self, field_name):
+        """ Helper to determine supported filter operations for a field """
+        if field_name not in self.fields:
+            raise InvalidFilterError("The '%s' field is not a valid field" % field_name)
+
+        try:
+            django_field_name = self.fields[field_name].attribute
+            django_field = self._meta.object_class._meta.get_field(django_field_name)
+            if hasattr(django_field, 'field'):
+                django_field = django_field.field  # related field
+        except FieldDoesNotExist:
+            raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
+
+        return django_field.get_lookups().keys()
+
+    def resolve_filter_type(self, field_name, filter_bits, default_filter_type=None):
+        """ Helper to derive filter type from next segment in filter bits """
+
+        if not filter_bits:
+            # No filter type to resolve, use default
+            return default_filter_type
+        elif filter_bits[0] not in self.get_query_terms(field_name):
+            # Not valid, maybe related field, use default
+            return default_filter_type
+        else:
+            # A valid filter type
+            return filter_bits[0]
 
     def filter_value_to_python(self, value, field_name, filters, filter_expr,
             filter_type):
@@ -2266,29 +2304,15 @@ class BaseModelResource(Resource):
         for filter_expr, value in list(filters.items()):
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
-            filter_type = 'exact'
 
-            if not field_name in self.fields:
+            if field_name not in self.fields:
                 # It's not a field we know about. Move along citizen.
                 continue
 
-            try:
-                django_field_name = self.fields[field_name].attribute
-                django_field = self._meta.object_class._meta.get_field(django_field_name)
-                if hasattr(django_field, "field"):
-                    django_field = django_field.field
-            except FieldDoesNotExist:
-                raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
-
-            query_terms = django_field.get_lookups().keys()
-            if len(filter_bits) and filter_bits[-1] in query_terms:
-                filter_type = filter_bits.pop()
-
+            filter_type = self.resolve_filter_type(field_name, filter_bits, 'exact')
             lookup_bits = self.check_filtering(field_name, filter_type, filter_bits)
             value = self.filter_value_to_python(value, field_name, filters, filter_expr, filter_type)
-
-            db_field_name = LOOKUP_SEP.join(lookup_bits)
-            qs_filter = "%s%s%s" % (db_field_name, LOOKUP_SEP, filter_type)
+            qs_filter = LOOKUP_SEP.join(lookup_bits)
             qs_filters[qs_filter] = value
 
         return dict_strip_unicode_keys(qs_filters)


### PR DESCRIPTION
There is a bug in Tastypie which considers query term as related field and
throws an error. There is a PR open for the fix in Tastypie's repository:
https://github.com/django-tastypie/django-tastypie/pull/1619/