### PR TITLE
HTO-2039: Use last value in filter bits as filter type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='django-tastypie',
-    version='0.18.0',
+    version='0.19.0',
     description='A flexible & capable API layer for Django.',
     author='Daniel Lindsley',
     author_email='daniel@toastdriven.com',

--- a/tastypie/__init__.py
+++ b/tastypie/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 
 __author__ = 'Daniel Lindsley & the Tastypie core team'
-__version__ = (0, 18, 0, 'dev')
+__version__ = (0, 19, 0, 'dev')
 
 from django.core.handlers.wsgi import WSGIRequest
 from .response_dispatcher import HttpResponseDispatcher

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2233,12 +2233,12 @@ class BaseModelResource(Resource):
         if not filter_bits:
             # No filter type to resolve, use default
             return default_filter_type
-        elif filter_bits[0] not in self.get_query_terms(field_name):
+        elif filter_bits[-1] not in self.get_query_terms(field_name):
             # Not valid, maybe related field, use default
             return default_filter_type
         else:
             # A valid filter type
-            return filter_bits[0]
+            return filter_bits[-1]
 
     def filter_value_to_python(self, value, field_name, filters, filter_expr,
             filter_type):


### PR DESCRIPTION
There is a bug in the current version of TastyPie. The filters on the nested attributes are not working. The `in` filter is getting ignored and instead the default filter `exact` is getting applied.

Reference - https://github.com/Aplopio/rbox_tastypie/pull/25, https://github.com/django-tastypie/django-tastypie/pull/1619