### PR TITLE
Django 3.2 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ local_settings.py
 .emacs*
 env
 env3
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ biplist
 # Because the official 0.1.4 release (that added Py3 support) HAS NO FILES.
 # mimeparse>=0.1.3
 python-mimeparse>=0.1.4
+six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.15
+Django==3.2.15
 python-dateutil>=2.6.0
 lxml
 defusedxml

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django import forms as djangoform
 from django.utils import datetime_safe
 from importlib import import_module
-from django.utils import six
+import six
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys, make_aware

--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -4,7 +4,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import object
 from django.conf import settings
-from django.utils import six
+import six
 
 from tastypie.exceptions import BadRequest
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -28,7 +28,7 @@ except ImportError:
 
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control, patch_vary_headers
-from django.utils import six
+import six
 
 from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -5,7 +5,7 @@ import re
 import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 from django.utils.encoding import force_text, smart_bytes
 from django.core.serializers import json as djangojson
 import json

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -6,7 +6,7 @@ import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 import six
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import force_str, smart_bytes
 from django.core.serializers import json as djangojson
 import json
 
@@ -221,7 +221,7 @@ class Serializer(object):
             raise UnsupportedFormat("The format indicated '%s' had no available deserialization method. Please check your ``formats`` and ``content_types`` on your Serializer." % format)
 
         if isinstance(content, six.binary_type):
-            content = force_text(content)
+            content = force_str(content)
 
         deserialized = getattr(self, "from_%s" % desired_format)(content)
         return deserialized
@@ -266,7 +266,7 @@ class Serializer(object):
         elif data is None:
             return None
         else:
-            return force_text(data)
+            return force_str(data)
 
     def to_etree(self, data, options=None, name=None, depth=0):
         """
@@ -326,7 +326,7 @@ class Serializer(object):
                 if isinstance(simple_data, six.text_type):
                     element.text = simple_data
                 else:
-                    element.text = force_text(simple_data)
+                    element.text = force_str(simple_data)
 
         return element
 

--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -8,7 +8,7 @@ import time
 from django.conf import settings
 from django.test import TestCase
 from django.test.client import FakePayload, Client
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from tastypie.serializers import Serializer
 
@@ -460,7 +460,7 @@ class ResourceTestCase(TestCase):
         """
         self.assertHttpOK(resp)
         self.assertTrue(resp['Content-Type'].startswith('application/json'))
-        self.assertValidJSON(force_text(resp.content))
+        self.assertValidJSON(force_str(resp.content))
 
     def assertValidXMLResponse(self, resp):
         """
@@ -473,7 +473,7 @@ class ResourceTestCase(TestCase):
         """
         self.assertHttpOK(resp)
         self.assertTrue(resp['Content-Type'].startswith('application/xml'))
-        self.assertValidXML(force_text(resp.content))
+        self.assertValidXML(force_str(resp.content))
 
     def assertValidYAMLResponse(self, resp):
         """
@@ -486,7 +486,7 @@ class ResourceTestCase(TestCase):
         """
         self.assertHttpOK(resp)
         self.assertTrue(resp['Content-Type'].startswith('text/yaml'))
-        self.assertValidYAML(force_text(resp.content))
+        self.assertValidYAML(force_str(resp.content))
 
     def assertValidPlistResponse(self, resp):
         """
@@ -499,7 +499,7 @@ class ResourceTestCase(TestCase):
         """
         self.assertHttpOK(resp)
         self.assertTrue(resp['Content-Type'].startswith('application/x-plist'))
-        self.assertValidPlist(force_text(resp.content))
+        self.assertValidPlist(force_str(resp.content))
 
     def deserialize(self, resp):
         """

--- a/tastypie/utils/dict.py
+++ b/tastypie/utils/dict.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from django.utils.encoding import smart_bytes
-from django.utils import six
+import six
 
 
 def dict_strip_unicode_keys(uni_dict):

--- a/tastypie/utils/http.py
+++ b/tastypie/utils/http.py
@@ -1,4 +1,4 @@
-from django.utils.six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 
 PROTOCOL_TO_PORT = {

--- a/tastypie/utils/validate_jsonp.py
+++ b/tastypie/utils/validate_jsonp.py
@@ -10,7 +10,7 @@ import re
 
 from unicodedata import category
 
-from django.utils import six
+import six
 
 # ------------------------------------------------------------------------------
 # javascript identifier unicode categories and "exceptional" chars

--- a/tests/alphanumeric/tests/http.py
+++ b/tests/alphanumeric/tests/http.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 import json
-from django.utils import six
+import six
 from testcases import TestServerTestCase
 
 try:

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -3,7 +3,7 @@ from future import standard_library
 standard_library.install_aliases()
 from testcases import TestServerTestCase
 import json
-from django.utils import six
+import six
 
 try:
     from .http.client import HTTPConnection

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -18,7 +18,7 @@ from django import forms
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
 from django.utils.encoding import force_text
-from django.utils import six
+import six
 
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -17,7 +17,7 @@ from django.core.urlresolvers import reverse
 from django import forms
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 import six
 
 from tastypie.authentication import BasicAuthentication
@@ -761,13 +761,13 @@ class ResourceTestCase(TestCase):
         data = {'hello': 'world'}
         output = basic.create_response(request, data)
         self.assertEqual(output.status_code, 200)
-        self.assertEqual(force_text(output.content), '{"hello": "world"}')
+        self.assertEqual(force_str(output.content), '{"hello": "world"}')
 
         request.GET = {'format': 'xml'}
         data = {'objects': [{'hello': 'world', 'abc': 123}], 'meta': {'page': 1}}
         output = basic.create_response(request, data)
         self.assertEqual(output.status_code, 200)
-        self.assertEqual(force_text(output.content), '<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<response><meta type="hash"><page type="integer">1</page></meta><objects type="list"><object type="hash"><abc type="integer">123</abc><hello>world</hello></object></objects></response>')
+        self.assertEqual(force_str(output.content), '<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<response><meta type="hash"><page type="integer">1</page></meta><objects type="list"><object type="hash"><abc type="integer">123</abc><hello>world</hello></object></objects></response>')
 
     def test_mangled(self):
         mangled = MangledBasicResource()
@@ -790,7 +790,7 @@ class ResourceTestCase(TestCase):
         request.GET = {'format': 'json'}
         request.method = 'GET'
 
-        basic_resource_list = json.loads(force_text(basic.get_list(request).content))['objects']
+        basic_resource_list = json.loads(force_str(basic.get_list(request).content))['objects']
         self.assertEquals(basic_resource_list[0]['name'], 'Daniel')
         self.assertEquals(basic_resource_list[0]['date_joined'], u'2010-03-30T09:00:00')
 
@@ -3001,7 +3001,7 @@ class ModelResourceTestCase(TestCase):
         # Try again with ``wrap_view`` for sanity.
         resp = resource.wrap_view('dispatch_detail')(request, pk=1)
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(force_text(resp.content), '{"error": "JSONP callback name is invalid."}')
+        self.assertEqual(force_str(resp.content), '{"error": "JSONP callback name is invalid."}')
         self.assertEqual(resp['content-type'], 'application/json')
 
         # valid JSONP callback should work
@@ -3819,23 +3819,23 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(punr._pre_limits, 0)
         # Shouldn't hit the DB yet.
         self.assertEqual(punr._post_limits, 0)
-        self.assertEqual(len(json.loads(force_text(punr.get_list(request=empty_request).content))['objects']), 4)
+        self.assertEqual(len(json.loads(force_str(punr.get_list(request=empty_request).content))['objects']), 4)
 
         # Requests with an Anonymous user get no objects.
         anony_bundle = punr.build_bundle(request=anony_request)
         self.assertEqual(punr.authorized_read_list(punr.get_object_list(anony_request), anony_bundle).count(), 0)
-        self.assertEqual(len(json.loads(force_text(punr.get_list(request=anony_request).content))['objects']), 0)
+        self.assertEqual(len(json.loads(force_str(punr.get_list(request=anony_request).content))['objects']), 0)
 
         # Requests with an authenticated user get all objects for that user
         # that are active.
         authed_bundle = punr.build_bundle(request=authed_request)
         self.assertEqual(punr.authorized_read_list(punr.get_object_list(authed_request), authed_bundle).count(), 2)
-        self.assertEqual(len(json.loads(force_text(punr.get_list(request=authed_request).content))['objects']), 2)
+        self.assertEqual(len(json.loads(force_str(punr.get_list(request=authed_request).content))['objects']), 2)
 
         # Demonstrate that a different user gets different objects.
         authed_bundle_2 = punr.build_bundle(request=authed_request_2)
         self.assertEqual(punr.authorized_read_list(punr.get_object_list(authed_request_2), authed_bundle_2).count(), 2)
-        self.assertEqual(len(json.loads(force_text(punr.get_list(request=authed_request_2).content))['objects']), 2)
+        self.assertEqual(len(json.loads(force_str(punr.get_list(request=authed_request_2).content))['objects']), 2)
         self.assertEqual(list(punr.authorized_read_list(punr.get_object_list(authed_request), authed_bundle).values_list('id', flat=True)), [1, 2])
         self.assertEqual(list(punr.authorized_read_list(punr.get_object_list(authed_request_2), authed_bundle_2).values_list('id', flat=True)), [4, 6])
 
@@ -3855,13 +3855,13 @@ class ModelResourceTestCase(TestCase):
         # Since the objects weren't filtered, we hit everything.
         self.assertEqual(ponr._post_limits, 6)
 
-        self.assertEqual(len(json.loads(force_text(ponr.get_list(request=empty_request).content))['objects']), 2)
+        self.assertEqual(len(json.loads(force_str(ponr.get_list(request=empty_request).content))['objects']), 2)
         self.assertEqual(ponr._pre_limits, 0)
         # Since the objects weren't filtered, we again hit everything.
         self.assertEqual(ponr._post_limits, 6)
 
         empty_request.GET['is_active'] = True
-        self.assertEqual(len(json.loads(force_text(ponr.get_list(request=empty_request).content))['objects']), 2)
+        self.assertEqual(len(json.loads(force_str(ponr.get_list(request=empty_request).content))['objects']), 2)
         self.assertEqual(ponr._pre_limits, 0)
         # This time, the objects were filtered, so we should only iterate over
         # a (hopefully much smaller) subset.
@@ -3989,7 +3989,7 @@ class ModelResourceTestCase(TestCase):
         resource = AlternativeCollectionNameNoteResource()
         request = HttpRequest()
         response = resource.get_list(request)
-        response_data = json.loads(force_text(response.content))
+        response_data = json.loads(force_str(response.content))
         self.assertTrue('alt_objects' in response_data)
 
 

--- a/tests/core/tests/throttle.py
+++ b/tests/core/tests/throttle.py
@@ -2,7 +2,7 @@ import time
 
 from django.core.cache import cache
 from django.test import TestCase
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from tastypie.models import ApiAccess
 from tastypie.throttle import BaseThrottle, CacheThrottle, CacheDBThrottle
@@ -137,5 +137,5 @@ class CacheDBThrottleTestCase(TestCase):
 class ModelTestCase(TestCase):
     def test_unicode(self):
         access = ApiAccess(identifier="testing", accessed=0)
-        self.assertEqual(force_text(access), 'testing @ 0')
+        self.assertEqual(force_str(access), 'testing @ 0')
 


### PR DESCRIPTION
## Context

This PR upgrades Django from `2.2.15` to `3.2.15` for this project.

## Changes introduced

1. Upgraded Django version to `3.2.15`
2. Added `six` to `requirements` and replaced all usages of `django.utils.six`. See release notes here - https://docs.djangoproject.com/en/4.1/releases/3.0/#removed-private-python-2-compatibility-apis
3.  It also replaces deprecated method `force_text` with `force_str` - https://docs.djangoproject.com/en/4.1/releases/3.0/#features-deprecated-in-3-0
